### PR TITLE
Fix JsonSerializationException when missing database feature

### DIFF
--- a/src/RimDev.AspNetCore.FeatureFlags/CachedSqlFeatureProvider.cs
+++ b/src/RimDev.AspNetCore.FeatureFlags/CachedSqlFeatureProvider.cs
@@ -3,7 +3,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Data.SqlClient;
-using System.Linq;
+using System.Diagnostics;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
@@ -98,9 +98,16 @@ namespace RimDev.AspNetCore.FeatureFlags
 
                 foreach (var feature in features)
                 {
-                    var value = JsonConvert.DeserializeObject(feature.Value, jsonSerializerSettings);
+                    try
+                    {
+                        var value = JsonConvert.DeserializeObject(feature.Value, jsonSerializerSettings);
 
-                    cache.AddOrUpdate(feature.Key, value, (_, __) => value);
+                        cache.AddOrUpdate(feature.Key, value, (_, __) => value);
+                    }
+                    catch (Exception ex)
+                    {
+                        Trace.WriteLine($"Unable to deserialize {feature.Key} from database: {ex.Message}");
+                    }
                 }
 
                 cacheLastUpdatedAt = DateTime.UtcNow;

--- a/src/RimDev.AspNetCore.FeatureFlags/RimDev.AspNetCore.FeatureFlags.csproj
+++ b/src/RimDev.AspNetCore.FeatureFlags/RimDev.AspNetCore.FeatureFlags.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>1.2.0</Version>
+    <Version>1.2.1</Version>
     <Description>A library for strongly typed feature flags in ASP.NET Core 2.2.</Description>
     <Authors>Ritter Insurance Marketing</Authors>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>


### PR DESCRIPTION
Fix JsonSerializationException that occurs when feature is added to
the database and later removed from the application.

A further enhancement could be cleaning up the database to avoid
these exceptions happening over and over but I'll leave that for the
future. This should get us working for now.