### PR TITLE
Lock when retrieving all features from database

### DIFF
--- a/samples/FeatureFlags.AspNetCore/Startup.cs
+++ b/samples/FeatureFlags.AspNetCore/Startup.cs
@@ -43,20 +43,23 @@ namespace FeatureFlags.AspNetCore
 
             app.UseEndpoints(endpoints =>
             {
-                endpoints.Map("/test-feature", async context =>
+                endpoints.Map("/test-features", async context =>
                 {
                     var testFeature = context.RequestServices.GetService<TestFeature>();
+                    var testFeature2 = context.RequestServices.GetService<TestFeature2>();
+                    var testFeature3 = context.RequestServices.GetService<TestFeature3>();
 
                     context.Response.ContentType = "text/html";
                     await context.Response.WriteAsync($@"
-                    {testFeature.GetType().Name}: {testFeature.Value}
-                    <br />
+                    {testFeature.GetType().Name}: {testFeature.Value}<br />
+                    {testFeature2.GetType().Name}: {testFeature2.Value}<br />
+                    {testFeature3.GetType().Name}: {testFeature3.Value}<br />
                     <a href=""{options.UiPath}"">View UI</a>");
                 });
 
                 endpoints.Map("", context =>
                 {
-                    context.Response.Redirect("/test-feature");
+                    context.Response.Redirect("/test-features");
 
                     return Task.CompletedTask;
                 });

--- a/src/RimDev.AspNetCore.FeatureFlags/RimDev.AspNetCore.FeatureFlags.csproj
+++ b/src/RimDev.AspNetCore.FeatureFlags/RimDev.AspNetCore.FeatureFlags.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;netcoreapp3.1</TargetFrameworks>
-    <Version>2.1.2</Version>
+    <Version>2.1.3</Version>
     <Description>A library for strongly typed feature flags in ASP.NET Core 3.1.</Description>
     <Authors>Ritter Insurance Marketing</Authors>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>


### PR DESCRIPTION
Use SemphoreSlim to prevent multiple simultaneous execution of the GetAllFeaturesFromDatabase database call. This can happen when multiple requests come into an ASP.NET Core application that require information about one or more feature flags and the cache is stale. Each request will independently call to the database until the cache has been built, rather than waiting for the first request. This should result in a small performance improvement, as well as reduce database load. Which, in situations of reasonable load coupled with unexpected SQL slowness, could result in many database requests stacking up.

Version 2.1.3