### PR TITLE
Dom-Xss Vulnerability

### DIFF
--- a/src/RimDev.AspNetCore.FeatureFlags/index.html
+++ b/src/RimDev.AspNetCore.FeatureFlags/index.html
@@ -7,6 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/material-design-lite/1.3.0/material.indigo-pink.min.css" integrity="sha256-TsamlRXOM65Pf69+MM9GIrkPUQscLDvQjgX60EpuWfk=" crossorigin="anonymous" />
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/dompurify/2.3.8/purify.min.js" integrity="sha512-M72KfQy4kPuLYC6CeTrN0eA17U1lXEMrr5qEJC/40CLdZGC3HpwPS0esQLqBHnxty2FIcuNdP9EqwSOCLEVJXQ==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
   <style>
     #features li {
       max-width: 650px;

--- a/src/RimDev.AspNetCore.FeatureFlags/main.js
+++ b/src/RimDev.AspNetCore.FeatureFlags/main.js
@@ -23,7 +23,7 @@ fetch('/_features/get_all', fetchOptions)
       </span>
     </li>`);
 
-    featuresContainer.innerHTML = features.join('');
+    featuresContainer.innerHTML = DOMPurify.sanitize(features.join(''));
 
     [...featuresContainer.getElementsByClassName('mdl-switch')].forEach(toggle => {
       componentHandler.upgradeElement(toggle);


### PR DESCRIPTION
One of our snyk vulnerabilities is a dom-xss potential attacks with the use of `innerHtml`. This includes a cdn link to [dompurify](https://github.com/cure53/DOMPurify) to be able to use a method to sanitize the html. Need to confirm the using this library will pass snyk scans. 