### PR TITLE
Replaces innerHtml with textContent

### DIFF
--- a/src/RimDev.AspNetCore.FeatureFlags.UI/main.js
+++ b/src/RimDev.AspNetCore.FeatureFlags.UI/main.js
@@ -13,7 +13,7 @@ var hideMessageContainer = () => {
 
 var removeMessage = (type) => {
   message.classList.remove('message--'+type+'');
-  messageText.innerHTML = "";
+  messageText.textContent = "";
 }
 
 let clearMessage;
@@ -21,7 +21,7 @@ let clearMessage;
 var showMessage = (text, type) => {
   messageContainer.classList.add('pin-bottom');
   message.classList.add('message--'+type+'');
-  messageText.innerHTML = text;
+  messageText.textContent = text;
 }
 
 var handleMessage = (text, type) => {
@@ -33,7 +33,6 @@ var handleMessage = (text, type) => {
 }
 
 var fireMessage = (text, type) => {
-
   if(messageContainer.classList.contains('pin-bottom')) {
     hideMessageContainer();
 


### PR DESCRIPTION
`innerHtml` isn't secure and flags our security scans. While we still assign the content with `innerHtml` we sanitize it beforehand. In the long run we want to switch from building the html as a string to pure JavaScript but this will help reduce usage of `innerHtml` 