### PR TITLE
Use TryAddSingleton() instead of AddSingleton*()

### DIFF
--- a/src/RimDev.AspNetCore.FeatureFlags.UI/UIStartupExtensions.cs
+++ b/src/RimDev.AspNetCore.FeatureFlags.UI/UIStartupExtensions.cs
@@ -2,6 +2,7 @@ using System;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace RimDev.AspNetCore.FeatureFlags.UI
 {
@@ -11,7 +12,7 @@ namespace RimDev.AspNetCore.FeatureFlags.UI
             this IServiceCollection service
             )
         {
-            service.AddSingleton<FeatureFlagUISettings>();
+            service.TryAddSingleton<FeatureFlagUISettings>();
             return service;
         }
 

--- a/src/RimDev.AspNetCore.FeatureFlags/StartupExtensions.cs
+++ b/src/RimDev.AspNetCore.FeatureFlags/StartupExtensions.cs
@@ -6,6 +6,7 @@ using LazyCache;
 using Lussatite.FeatureManagement.SessionManagers.SqlClient;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.FeatureManagement;
 
 namespace RimDev.AspNetCore.FeatureFlags
@@ -65,7 +66,7 @@ namespace RimDev.AspNetCore.FeatureFlags
             string initializationConnectionString
             )
         {
-            services.AddSingleton(serviceProvider =>
+            services.TryAddSingleton(serviceProvider =>
             {
                 if (string.IsNullOrEmpty(connectionString))
                     throw new ArgumentNullException(nameof(connectionString));
@@ -117,7 +118,7 @@ namespace RimDev.AspNetCore.FeatureFlags
             this IServiceCollection services
             )
         {
-            services.AddSingleton(serviceProvider =>
+            services.TryAddSingleton(serviceProvider =>
             {
                 var featureFlagsSettings = serviceProvider.GetRequiredService<FeatureFlagsSettings>();
                 var appCache = serviceProvider.GetService<IAppCache>();


### PR DESCRIPTION
By switching to TryAddSingleton(), it gives the user of the package the
ability to register their version of options/settings singletons and not
have it be overridden by the default version in the package.