### PR TITLE
Test out a secondary schema, created on demand

### DIFF
--- a/samples/FeatureFlags.AspNetCore/Startup.cs
+++ b/samples/FeatureFlags.AspNetCore/Startup.cs
@@ -1,6 +1,8 @@
 using System.Linq;
 using System.Threading.Tasks;
 using Lussatite.FeatureManagement;
+using Lussatite.FeatureManagement.SessionManagers;
+using Lussatite.FeatureManagement.SessionManagers.SqlClient;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
@@ -30,11 +32,17 @@ namespace FeatureFlags.AspNetCore
             var featureFlagsInitializationConnectionString
                 = configuration.GetConnectionString("featureFlagsInitialization");
 
+            var sqlSessionManagerSettings = new SQLServerSessionManagerSettings
+            {
+                FeatureSchemaName = "features",
+            };
+
             services.AddRimDevFeatureFlags(
                 configuration,
                 new[] { typeof(Startup).Assembly },
                 connectionString: featureFlagsConnectionString,
-                initializationConnectionString: featureFlagsInitializationConnectionString
+                initializationConnectionString: featureFlagsInitializationConnectionString,
+                sqlSessionManagerSettings: sqlSessionManagerSettings
                 );
 
             // IFeatureManagerSnapshot should always be scoped / per-request lifetime

--- a/src/RimDev.AspNetCore.FeatureFlags.Core/StartupExtensions.cs
+++ b/src/RimDev.AspNetCore.FeatureFlags.Core/StartupExtensions.cs
@@ -1,3 +1,4 @@
+using System.Data.SqlClient;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -9,26 +10,54 @@ namespace RimDev.AspNetCore.FeatureFlags.Core
             this IApplicationBuilder app
             )
         {
+            if (_sessionManagerInitialized) return app;
+
+            app.CreateFeatureFlagsSchema();
             app.CreateFeatureFlagsTable();
+            _sessionManagerInitialized = true;
+
             return app;
         }
 
         private static bool _sessionManagerInitialized;
+
+        /// <summary>Create the feature flags schema (must be done via a defensive SQL script).</summary>
+        public static IApplicationBuilder CreateFeatureFlagsSchema(
+            this IApplicationBuilder app
+            )
+        {
+            var featureFlagsSettings = app
+                .ApplicationServices
+                .GetRequiredService<FeatureFlagsSettings>();
+
+            if (!string.IsNullOrEmpty(featureFlagsSettings?.SqlSessionManagerSettings?.FeatureSchemaName))
+            {
+                using var conn = new SqlConnection(featureFlagsSettings.InitializationConnectionString);
+                conn.Open();
+                using var cmd = conn.CreateCommand();
+                var schema = featureFlagsSettings.SqlSessionManagerSettings.FeatureSchemaName;
+                cmd.CommandText = @$"
+IF NOT EXISTS (SELECT * FROM sys.schemas WHERE name = N'{schema}')
+EXEC('CREATE SCHEMA [{schema}];');";
+                cmd.ExecuteNonQuery();
+                conn.Close();
+            }
+
+            return app;
+        }
 
         /// <summary>Create the feature flags table (must be done via a defensive SQL script).</summary>
         public static IApplicationBuilder CreateFeatureFlagsTable(
             this IApplicationBuilder app
             )
         {
-            if (_sessionManagerInitialized) return app;
-
             var featureFlagsSettings = app
                 .ApplicationServices
                 .GetRequiredService<FeatureFlagsSettings>();
+
             featureFlagsSettings.SqlSessionManagerSettings.CreateDatabaseTable(
                 featureFlagsSettings.InitializationConnectionString
-            );
-            _sessionManagerInitialized = true;
+                );
 
             return app;
         }


### PR DESCRIPTION
Add a "create schema if not exists" which will fire off when the schema
property is not null/empty.